### PR TITLE
Fail on any legal state that is not ACCEPTED

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -128,7 +128,7 @@ Apache License Version 2.0
 
 * org.w3c.dom.svg_1.1.0.v201011041433.jar
 
-* org.zeroturnaround.zt-exec-sources.jar
+* org.zeroturnaround.zt-exec.jar
 
 
 

--- a/releng/org.aposin.gem.parent/licensescout/checkedarchives.csv
+++ b/releng/org.aposin.gem.parent/licensescout/checkedarchives.csv
@@ -1,4 +1,5 @@
 Type,Filename or Regex,Version or Message digest,Documentation URL,Provider,Notice,License 1,License 2, License 3
 JAVA,com.typesafe.config.jar,1.4.0,,,,Apache-2.0
+JAVA,org.zeroturnaround.zt-exec.jar,5B9131CA9DE1477E3F38BB4E6EF951ED13D1EDF34329D1A98D6F48E174523233,,,,Apache-2.0
 JAVA,com.ibm.icu_64.2.0.v20190507-1337.jar,64.2.0.v20190507-1337,,EclipseFoundation,,EPL-1.0
-JAVA,javax.annotation_1.2.0.v201602091430.jar,1.2.0.v201602091430,,EclipseFoundation,,EPL-1.0,,
+JAVA,javax.annotation_1.2.0.v201602091430.jar,1.2.0.v201602091430,,EclipseFoundation,,EPL-1.0

--- a/releng/org.aposin.gem.parent/pom.xml
+++ b/releng/org.aposin.gem.parent/pom.xml
@@ -170,6 +170,8 @@ limitations under the License.
 					<nexusCentralBaseUrl>${licensescout.nexusCentralBaseUrl}</nexusCentralBaseUrl>
 					<writeResultsToDatabase>${licensescout.writeResultsToDatabase}</writeResultsToDatabase>
 					<writeResultsToDatabaseForSnapshotBuilds>false</writeResultsToDatabaseForSnapshotBuilds>
+					<errorLegalStates>NOT_ACCEPTED,CONFLICTING,UNKNOWN</errorLegalStates>
+					<failOnError>true</failOnError>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
Currently the not `ACCEPTED` libs that are on the project does not make the build fail (found with `org.zeroturnaround.zt-exec` wrongly identified with the sources instead with the binary where the license information is not found).

* The first commit demonstrate how the failure would look like on the checks.
* The second commit adds the detection for the lib that is `UNKNOWN`
* The third commit updates the NOTICE.txt to be sure that it is using the correct jar name