### PR TITLE
Upgrade org.zeroturnaround:zt-exec to 1.12

### DIFF
--- a/bundles/org.aposin.gem.core/pom.xml
+++ b/bundles/org.aposin.gem.core/pom.xml
@@ -17,7 +17,7 @@
 	<properties>
 		<lib-output-folder>lib</lib-output-folder>
 		<config.version>1.4.1</config.version>
-		<zt-exec.version>1.11</zt-exec.version>
+		<zt-exec.version>1.12</zt-exec.version>
 	</properties>
 	
 	<dependencies>

--- a/releng/org.aposin.gem.parent/licensescout/checkedarchives.csv
+++ b/releng/org.aposin.gem.parent/licensescout/checkedarchives.csv
@@ -1,5 +1,5 @@
 Type,Filename or Regex,Version or Message digest,Documentation URL,Provider,Notice,License 1,License 2, License 3
 JAVA,com.typesafe.config.jar,1.4.1,,,,Apache-2.0
-JAVA,org.zeroturnaround.zt-exec.jar,5B9131CA9DE1477E3F38BB4E6EF951ED13D1EDF34329D1A98D6F48E174523233,,,,Apache-2.0
+JAVA,org.zeroturnaround.zt-exec.jar,F513AF3998FD4024F993E8B259EFD36B34A0CF1C793E93B4A25ADC3498D011FD,,,,Apache-2.0
 JAVA,com.ibm.icu_64.2.0.v20190507-1337.jar,64.2.0.v20190507-1337,,EclipseFoundation,,EPL-1.0
 JAVA,javax.annotation_1.2.0.v201602091430.jar,1.2.0.v201602091430,,EclipseFoundation,,EPL-1.0


### PR DESCRIPTION
Replaces #28 with required update to licensescout configuration.