### PR TITLE
Remove system props replacement on EclipseLauncher

### DIFF
--- a/bundles/org.aposin.gem.oomph/src/org/aposin/gem/oomph/EclipseLauncher.java
+++ b/bundles/org.aposin.gem.oomph/src/org/aposin/gem/oomph/EclipseLauncher.java
@@ -24,7 +24,6 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
@@ -260,11 +259,7 @@ public class EclipseLauncher extends AbstractNoParamsLauncher implements IConfig
                             "org.eclipse.oomph.p2");
                 } else {
                     // Split slash and backslash
-                    final String[] bundlePoolConfigSplit = bundlePoolConfigString.split("[/\\\\]");
-                    bundlePoolConfigPath = Paths.get("", //
-                            Arrays.stream(bundlePoolConfigSplit) //
-                                    .map(EclipseLauncher::mapSystemProperty)
-                                    .toArray(String[]::new));
+                    bundlePoolConfigPath = Paths.get(bundlePoolConfigString);
                 }
                 if (Files.notExists(bundlePoolConfigPath)) {
                     Files.createDirectories(bundlePoolConfigPath);
@@ -275,24 +270,6 @@ public class EclipseLauncher extends AbstractNoParamsLauncher implements IConfig
                 LOGGER.error("Could not set bundle pool.", e);
             }
         }
-    }
-
-    /**
-     * Checks and replaces the given {@link String} variable, e.g. <code>${user.home}</code>,
-     * against the given system properties. If the input does not exist as system property it
-     * returns the input unchanged.
-     * 
-     * @param s the variable to replace against available system properties
-     * @return the value from system properties or the input if replacement is not possible.
-     */
-    private static String mapSystemProperty(final String s) {
-        if (s != null && s.startsWith("${") && s.endsWith("}")) {
-            final String prop = System.getProperty(s.substring(2, s.length() - 1));
-            if (prop != null) {
-                return prop;
-            }
-        }
-        return s;
     }
 
     /**


### PR DESCRIPTION
## Type of request
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring 
- [ ] Documentation or documentation changes

## Related Issue(s)

Requires https://github.com/aposin/gem-config/pull/2

## Concept 

Remove the workaround to substitute the system properties on the `EclipseLauncher`, as it is handled by the HOCON parser by using the proper syntax.

## Checklist:

- [x] All the commits are signed.
- [x] My code follows the code style of this project.
- [x] I agree with die CLA.
- [x] I have read the CONTRIBUTING docs.
- [x] I have added/updated necessary documentation (if appropriate).
