### PR TITLE
Use Eclipse folder as process working directory

### DIFF
--- a/bundles/org.aposin.gem.core/src/org/aposin/gem/core/utils/ExecUtils.java
+++ b/bundles/org.aposin.gem.core/src/org/aposin/gem/core/utils/ExecUtils.java
@@ -53,6 +53,19 @@ public final class ExecUtils {
      * Similar to {@link Runtime#exec(String[])}, but discarding stdout/stderr.
      * 
      * @param cmdArgs command and arguments tokenized and quoted if required.
+     * @return running process.
+     * @throws IOException if the command fails to launch
+     */
+    public static Process exec(final List<String> cmdArgs) throws IOException {
+        return exec(cmdArgs, null);
+    }
+
+    /**
+     * Executes the specified command and arguments in a separate process.
+     * </br>
+     * Similar to {@link Runtime#exec(String[])}, but discarding stdout/stderr.
+     * 
+     * @param cmdArgs command and arguments tokenized and quoted if required.
      * @param directory the process working directory.
      * @return running process.
      * @throws IOException if the command fails to launch

--- a/bundles/org.aposin.gem.core/src/org/aposin/gem/core/utils/ExecUtils.java
+++ b/bundles/org.aposin.gem.core/src/org/aposin/gem/core/utils/ExecUtils.java
@@ -53,11 +53,13 @@ public final class ExecUtils {
      * Similar to {@link Runtime#exec(String[])}, but discarding stdout/stderr.
      * 
      * @param cmdArgs command and arguments tokenized and quoted if required.
+     * @param directory the process working directory.
      * @return running process.
      * @throws IOException if the command fails to launch
      */
-    public static Process exec(final List<String> cmdArgs) throws IOException {
+    public static Process exec(final List<String> cmdArgs, Path directory) throws IOException {
         return new ProcessBuilder(cmdArgs) //
+            .directory(directory == null ? null : directory.toFile())
             .redirectOutput(Redirect.DISCARD) //
             .redirectError(Redirect.DISCARD) //
             .start();

--- a/bundles/org.aposin.gem.oomph/src/org/aposin/gem/oomph/EclipseLauncher.java
+++ b/bundles/org.aposin.gem.oomph/src/org/aposin/gem/oomph/EclipseLauncher.java
@@ -178,7 +178,7 @@ public class EclipseLauncher extends AbstractNoParamsLauncher implements IConfig
             if (LOGGER.isInfoEnabled()) {
                 LOGGER.info("Eclipse command: '{}'", cmd.stream().collect(Collectors.joining(" ")));
             }
-            ExecUtils.exec(cmd);
+            ExecUtils.exec(cmd, eclipseFolder);
         } catch (final IOException e) {
             LOGGER.error("Could not start Eclipse.", e);
             throw new GemException("Could not start eclipse.", e);

--- a/bundles/org.aposin.gem.tortoisegit/src/org/aposin/gem/tortoisegit/launcher/AbstractTortoiseGitLauncher.java
+++ b/bundles/org.aposin.gem.tortoisegit/src/org/aposin/gem/tortoisegit/launcher/AbstractTortoiseGitLauncher.java
@@ -111,7 +111,7 @@ abstract class AbstractTortoiseGitLauncher implements ILauncher {
         try {
             final List<String> arguments = getCommonArguments();
             arguments.addAll(extraArguments);
-            ExecUtils.exec(arguments);
+            ExecUtils.exec(arguments, null);
         } catch (final IOException e) {
             throw new GemException("Error running TortoiseGit", e);
         }

--- a/bundles/org.aposin.gem.tortoisegit/src/org/aposin/gem/tortoisegit/launcher/AbstractTortoiseGitLauncher.java
+++ b/bundles/org.aposin.gem.tortoisegit/src/org/aposin/gem/tortoisegit/launcher/AbstractTortoiseGitLauncher.java
@@ -111,7 +111,7 @@ abstract class AbstractTortoiseGitLauncher implements ILauncher {
         try {
             final List<String> arguments = getCommonArguments();
             arguments.addAll(extraArguments);
-            ExecUtils.exec(arguments, null);
+            ExecUtils.exec(arguments);
         } catch (final IOException e) {
             throw new GemException("Error running TortoiseGit", e);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!---  
*DO keep Pull Requests small so they can be easily reviewed.*
 *DO make sure your contribution fits the openness and scalability for future extensions*
 *DO make sure unit tests pass.*
 *DO make sure any public APIs are XML documented.*
 *DO make sure not to introduce any compiler warnings.*
 *AVOID making significant changes to the driver's overall architecture.*
*Delete the above section and the instructions in the sections below before submitting.* 
--->

## Type of request
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring 
- [ ] Documentation or documentation changes

## Related Issue(s)
<!--- This project only accepts Pull Requests related to open Issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Lombok adds an agent path to the vmargs. By default it is possible to define a relative path to the Lombok plugin within the installation:
`-javaagent:plugins/org.projectlombok.agent_1.18.22/lombok.jar`
So this path is correctly working it is necessary that Eclipse is started from it's folder as process working directory. Otherwise Eclipse is not starting as the relativ path cannot be resolved. 

## Concept 
Instead of using the default process working directory (by default user.dir). it is possible to provide the directory where a process is started from. 


## Technical information
#### Platform / target area
<!--- What platform(s) is effected? -->
All platforms.

#### known side-effects
Eclipse process is started and executed from it's original directory, instead of the user directory. 

#### How has this Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Simply start Eclipse with a Lombok installation, containing the following vmarg: `-javaagent:plugins/org.projectlombok.agent_1.18.22/lombok.jar`
- Check TortoiseGit is still working as expected by clicking on Log or Status

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] All the commits are signed.
- [x] My code follows the code style of this project.
- [x] I agree with die CLA.
- [x] I have read the CONTRIBUTING docs.
- [x] I have added/updated necessary documentation (if appropriate).
